### PR TITLE
wip: databricks cross-account role + policy attachment, matching setup-complete

### DIFF
--- a/modules/internal/databricks/iam/cross_account.tf
+++ b/modules/internal/databricks/iam/cross_account.tf
@@ -1,0 +1,87 @@
+/* ╭──────────────────────────────────────────────────────────╮
+   │ IAM role which is used to write to the online store      │
+   │  (DynamoDB) when Databricks lives in a separate          │
+   │  account from the Tecton deployment                      │
+   ╰──────────────────────────────────────────────────────────╯
+*/
+resource "aws_iam_role" "tecton_spark_cross_account" {
+  count = local.is_databricks_in_tecton_account ? 0 : 1
+
+  name                 = format("tecton-%s-cross-account-spark-access", var.deployment_name)
+  max_session_duration = 43200
+  tags                 = local.tags
+  assume_role_policy   = data.aws_iam_policy_document.assume_role.json
+
+  provider = aws.tecton
+}
+
+data "aws_iam_policy_document" "assume_role" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "AWS"
+      identifiers = local.tecton_cross_account_role_trusted_arns
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "sts:ExternalId"
+      values   = [random_id.external_id[0].id]
+    }
+  }
+}
+
+resource "random_id" "external_id" {
+  count = local.is_databricks_in_tecton_account ? 1 : 0
+
+  byte_length = 16
+}
+
+resource "aws_iam_role_policy_attachment" "cross_account_databricks_policy_attachment" {
+  count = local.is_databricks_in_tecton_account ? 0 : 1
+
+  policy_arn = aws_iam_policy.cross_account_databricks[0].arn
+  role       = aws_iam_role.tecton_spark_cross_account[0].name
+
+  provider = aws.tecton
+}
+
+resource "aws_iam_policy" "cross_account_databricks" {
+  count = local.is_databricks_in_tecton_account ? 0 : 1
+
+  name   = format("tecton-%s-cross-account-databricks", var.deployment_name)
+  policy = data.aws_iam_policy_document.tecton_spark_cross_account_access.json
+  tags   = local.tags
+
+  provider = aws.tecton
+}
+
+data "aws_iam_policy_document" "tecton_spark_cross_account_access" {
+  statement {
+    sid    = "DynamoDB"
+    effect = "Allow"
+    resources = [
+      format(
+        "arn:aws:dynamodb:%s:%s:table/tecton-%s*",
+        local.region_tecton, # DynamoDB table will be created by Tecton provider
+        local.account_id_tecton,
+        var.deployment_name,
+      )
+    ]
+
+    actions = [
+      "dynamodb:ConditionCheckItem",
+      "dynamodb:DescribeTable",
+      "dynamodb:GetItem",
+      "dynamodb:PutItem",
+    ]
+  }
+
+  statement {
+    sid       = "DynamoDBListTables"
+    effect    = "Allow"
+    resources = ["*"]
+    actions   = ["dynamodb:ListTables"]
+  }
+}

--- a/modules/internal/databricks/iam/locals.tf
+++ b/modules/internal/databricks/iam/locals.tf
@@ -5,6 +5,9 @@ module "deployment_name" {
 
 locals {
   deployment_name = module.deployment_name.deployment_name
+  s3_bucket_arns = var.s3_bucket_arns != null ? var.s3_bucket_arns : [
+    format("arn:aws:s3:::tecton-%s", var.deployment_name),
+  ]
 
   account_id             = data.aws_caller_identity.current.account_id
   databricks_account_id  = data.aws_caller_identity.databricks.id

--- a/modules/internal/databricks/iam/main.tf
+++ b/modules/internal/databricks/iam/main.tf
@@ -1,3 +1,5 @@
+# TODO: go through this file + move/cover in cross + spark files
+
 data "aws_iam_role" "spark_role" {
   name = var.spark_role_name
 }

--- a/modules/internal/databricks/iam/spark_policy.tf
+++ b/modules/internal/databricks/iam/spark_policy.tf
@@ -1,0 +1,98 @@
+/* ╭──────────────────────────────────────────────────────────╮
+   │ Policy grants existing Databricks role (should           │
+   │  already exist) access to Tecton resources               │
+   ╰──────────────────────────────────────────────────────────╯
+*/
+resource "aws_iam_role_policy_attachment" "common_spark_policy_attachment" {
+  policy_arn = aws_iam_policy.spark_access.arn
+  role       = local.spark_role_name
+  provider   = aws.databricks
+}
+
+resource "aws_iam_policy" "spark_access" {
+  name     = format("tecton-%s-common-spark", var.deployment_name)
+  policy   = data.aws_iam_policy_document.spark_access.json
+  tags     = local.tags
+  provider = aws.databricks
+}
+
+data "aws_iam_policy_document" "spark_access" {
+  statement {
+    sid    = "DynamoDB"
+    effect = "Allow"
+    resources = [
+      format(
+        "arn:aws:dynamodb:%s:%s:table/tecton-%s*",
+        local.region_tecton, # DynamoDB table will be created by Tecton provider
+        local.account_id_tecton,
+        var.deployment_name,
+      )
+    ]
+
+    actions = [
+      "dynamodb:BatchWriteItem",
+      "dynamodb:ConditionCheckItem",
+      "dynamodb:DescribeTable",
+      "dynamodb:PutItem",
+      "dynamodb:GetItem",
+      "dynamodb:Query",
+    ]
+  }
+
+  statement {
+    sid       = "DynamoDBGlobal"
+    effect    = "Allow"
+    resources = ["*"]
+    actions   = ["dynamodb:ListTables"]
+  }
+
+  statement {
+    sid     = "S3Bucket"
+    effect  = "Allow"
+    actions = ["s3:ListBucket"]
+
+    resources = concat(var.s3_bucket_arns, [
+      "arn:aws:s3:::tecton.ai.databricks-init-scripts",
+      "arn:aws:s3:::tecton.ai.public",
+      "arn:aws:s3:::tecton-materialization-release",
+    ])
+  }
+
+  statement {
+    sid       = "S3Object"
+    effect    = "Allow"
+    resources = formatlist("%s/*", var.s3_bucket_arns)
+
+    actions = [
+      "s3:GetObject",
+      "s3:PutObject",
+      "s3:DeleteObject",
+    ]
+  }
+
+  statement {
+    sid    = "TectonPublicS3"
+    effect = "Allow"
+
+    resources = [
+      "arn:aws:s3:::tecton.ai.databricks-init-scripts/*",
+      "arn:aws:s3:::tecton.ai.public/*",
+      "arn:aws:s3:::tecton-materialization-release/*",
+    ]
+
+    actions = ["s3:GetObject"]
+  }
+
+  statement {
+    sid    = "CrossAccountDynamoDBAccess"
+    effect = "Allow"
+    resources = [
+      format(
+        "arn:aws:iam::%s:role/tecton-%s-cross-account-spark-access",
+        local.account_id_tecton,
+        var.deployment_name,
+      )
+    ]
+    actions = ["sts:AssumeRole"]
+  }
+}

--- a/modules/internal/databricks/iam/variables.tf
+++ b/modules/internal/databricks/iam/variables.tf
@@ -17,6 +17,15 @@ variable "deployment_type" {
   }
 }
 
+variable "s3_bucket_arns" {
+  description = <<EOV
+ARNs of the S3 buckets which Spark should have access to. Should include the Tecton deployment
+bucket. Defaults to just the deployment bucket (`tecton-${var.deployment_name}`) if not specified.
+EOV
+  default     = null
+  type        = list(string)
+}
+
 variable "spark_role_name" {
   type        = string
   description = "The name of the spark role used for Databricks to attach policies to."
@@ -26,4 +35,13 @@ variable "tags" {
   type        = map(string)
   default     = {}
   description = "Additional tags to apply to resources."
+}
+
+variable "tecton_cross_account_role_trusted_arns" {
+  description = <<EOV
+ARNs which should be allowed to assume the cross-account role if Databricks lives in a separate
+account from the Tecton deployment. Defaults to the aws.databricks provider account.
+EOV
+  default     = []
+  type        = list(string)
 }

--- a/modules/internal/databricks/iam/versions.tf
+++ b/modules/internal/databricks/iam/versions.tf
@@ -2,8 +2,9 @@ terraform {
   required_version = ">= 0.13.5"
   required_providers {
     aws = {
-      version = ">= 3"
-      source  = "hashicorp/aws"
+      version               = ">= 3"
+      source                = "hashicorp/aws"
+      configuration_aliases = [aws.tecton, aws.databricks]
     }
     random = {
       version = ">= 3"
@@ -12,6 +13,22 @@ terraform {
   }
 }
 
+/* ╭──────────────────────────────────────────────────────────╮
+   │ provider blocks should be removed in favor of            │
+   │  configuration_aliases (above) once                      │
+   │  https://github.com/hashicorp/terraform/issues/28490     │
+   │  is resolved                                             │
+   ╰──────────────────────────────────────────────────────────╯
+
+*/
+
+# Tecton deployment account
+provider "aws" {
+  alias = "tecton"
+}
+
+# Databricks deployment account
+#  may be the same or different from Tecton above
 provider "aws" {
   alias = "databricks"
 }


### PR DESCRIPTION
Trues up the databricks attached IAM policy + the cross-account role based on setup-complete