### PR TITLE
fix(privatelink-cross-vpc): add vpce_id + set private_dns_enabled = false

### DIFF
--- a/modules/privatelink-cross-vpc/README.md
+++ b/modules/privatelink-cross-vpc/README.md
@@ -45,4 +45,5 @@ No modules.
 | Name | Description |
 |------|-------------|
 | <a name="output_caller_identity"></a> [caller\_identity](#output\_caller\_identity) | Current caller identity |
+| <a name="output_vpc_endpoint_id"></a> [vpc\_endpoint\_id](#output\_vpc\_endpoint\_id) | n/a |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/privatelink-cross-vpc/main.tf
+++ b/modules/privatelink-cross-vpc/main.tf
@@ -28,7 +28,7 @@ resource "aws_vpc_endpoint" "cross_vpc" {
   subnet_ids          = var.vpc_endpoint_subnet_ids
   vpc_endpoint_type   = "Interface"
   auto_accept         = true
-  private_dns_enabled = true
+  private_dns_enabled = false
 }
 
 resource "aws_route53_zone" "private" {

--- a/modules/privatelink-cross-vpc/outputs.tf
+++ b/modules/privatelink-cross-vpc/outputs.tf
@@ -2,3 +2,7 @@ output "caller_identity" {
   description = "Current caller identity"
   value       = data.aws_caller_identity.current
 }
+
+output "vpc_endpoint_id" {
+  value = aws_vpc_endpoint.cross_vpc.id
+}


### PR DESCRIPTION
## What

Adds the VPC endpoint ID output and sets private_dns_enabled to false for the endpoint.

## Why

1. The VPC endpoint ID is needed to pass on to other modules
2. We're creating private R53 DNS entries here so setting private_dns_enabled should always be false
    - Setting to true requires domain validation, which we don't want

## Test Plan

Tested locally on dev cluster
